### PR TITLE
Fix bug where not detecting the LaTeX files.

### DIFF
--- a/lib/latex-tree.js
+++ b/lib/latex-tree.js
@@ -192,7 +192,7 @@ export default {
         if (!paneItem)
             return false;
         return (paneItem.getRootScopeDescriptor().getScopesArray()[0]
-            === 'text.tex.latex');
+                .indexOf(''text.tex.latex'') > -1);
     }
 
 };

--- a/lib/latex-tree.js
+++ b/lib/latex-tree.js
@@ -192,7 +192,7 @@ export default {
         if (!paneItem)
             return false;
         return (paneItem.getRootScopeDescriptor().getScopesArray()[0]
-                .indexOf(''text.tex.latex'') > -1);
+                .indexOf('text.tex.latex') > -1);
     }
 
 };


### PR DESCRIPTION
The filetype is now text.tex.latex.beamer but this means it is no longer an exact match. Instead match using indexOf to find the first occurance of `text.tex.latex`. If no match then indexOf returns -1 which evaluates to false.

Also relevant for  #7 

This is probably caused by Atom-Latex misdetecting the documentclass but this doesn't affect the tree structure. 
As seen in https://github.com/James-Yu/Atom-LaTeX/blob/8188e97ee0f89f3b43c977581aa60d332a12fb50/lib/view/status.js#L69