### PR TITLE
Add support for backmatter and frontmatter sections

### DIFF
--- a/lib/DocTree.js
+++ b/lib/DocTree.js
@@ -86,7 +86,7 @@ export default class DocTree {
     // Can be recursively called (need to make sure not calling the same
     // buffer / infinite recursive loop)
     appendToDocTree (buff, prevLvl, overrideRootDir) {
-        let regEx = new RegExp(/\\(include(?:from)?|input(?:from)?|(?:sub)?import|sub(?:input|include)from|part|chapter|(?:sub){0,2}section|(?:sub)?paragraph)(?:\s*(?:%.*\s*)*\*?\s*(?:%.*\s*)*{|\s*(?:%.*\s*)*\[)/, 'gm');
+        let regEx = new RegExp(/\\(include(?:from)?|input(?:from)?|(?:sub)?import|sub(?:input|include)from|part|chapter|(?:sub){0,2}section|(?:sub)?paragraph)(?:\s*(?:%.*\s*)*\*?\s*(?:%.*\s*)*{|\s*(?:%.*\s*)*\[)|\\((?:front|back)matter)/, 'gm');
 
         // Scan text buffer for regex
         buff.scan(regEx, result => {

--- a/lib/ParseObject.js
+++ b/lib/ParseObject.js
@@ -7,6 +7,8 @@ const path = require('path');
 const LEVELS_FOR_WORDS = {
     'part': 1,
     'chapter': 2,
+	'frontmatter': 2,
+	'backmatter': 2,
     'section': 3,
     'subsection': 4,
     'subsubsection': 5,
@@ -21,6 +23,10 @@ const LEVELS_FOR_WORDS = {
     'includefrom': -3,
     'subincludefrom': -4
 };
+const TITLES_FOR_WORDS = {
+	'frontmatter': 'Front Matter',
+	'backmatter': 'Back Matter'
+}
 
 // ParseObject: encapsulates parsing of text and storing the parsed information
 export default class ParseObject {
@@ -28,10 +34,12 @@ export default class ParseObject {
         this.matchStartPt = new Point(result.range.start.row, result.range.start.column);
         this.buffer = buffNow;
         this.pointNow = new Point(result.range.end.row, result.range.end.column);
-        // result.match[1] is the captured word in regex, mapping with the
-        // LEVELS_FOR_WORDS object gives correct level number
-        this.level = LEVELS_FOR_WORDS[result.match[1]];
-        this.text = null;
+        // result.match[1] is the captured word in regex, 
+		// result.match[2] is for structure exceptions like mainmatter.
+		// mapping with the LEVELS_FOR_WORDS object gives correct level number
+        this.level = LEVELS_FOR_WORDS[result.match[1]||result.match[2]];
+		// The structure exceptions do not come with titles so define them in TITLES_FOR_WORDS
+        this.text = TITLES_FOR_WORDS[result.match[2]];
         this.text2 = null; // for levels -3 & -4 only
     }
 
@@ -79,8 +87,12 @@ export default class ParseObject {
         if (this.skipAllComments() === null)
             return null;
 
-        // Get main title
-        if (this.buffer.lineForRow(this.pointNow.row)[this.pointNow.column-1]
+        // Get main title if not already defined
+		if (this.text){
+			//It is defined so do nothing
+			debugger;
+		}
+        else if (this.buffer.lineForRow(this.pointNow.row)[this.pointNow.column-1]
             === '{') {
             // Get text of title
             this.text = this.getText('}');


### PR DESCRIPTION
![ExampleOfFrontMatter](https://user-images.githubusercontent.com/693456/60512283-1751a980-9ccc-11e9-8b7c-aeae9c8a6e94.PNG)

Addressing #9 

Changes
--------
* Modified the matching Regex to find a second group of
structural elements not like the first
* Include the second match for the level number if no first match
* Add preprogrammed titles for two new elements because
the normal title detecting code will not find any

Shortcomings
------------
If the user has parts or does not have chapters, the frontmatter
and backmatter parts will be on the wrong level