### PR TITLE
added check for pane destroyed

### DIFF
--- a/lib/latex-tree-view.js
+++ b/lib/latex-tree-view.js
@@ -228,7 +228,7 @@ export default class LatexTreeView {
             }
             this.highlight(nodeIndex);
             let docNodeNow = this.docTree[this.selectedNowInd];
-            if (docNodeNow.filePath === this.textEditorNow.getPath())
+            if (atom.workspace.paneForItem(this.textEditorNow) != null && docNodeNow.filePath === this.textEditorNow.getPath())
                 this.textEditorNow.setCursorBufferPosition(docNodeNow.startPt);
 
             else {
@@ -253,7 +253,9 @@ export default class LatexTreeView {
     // Just focuses on the text editor so user can continue typing right away
     focusTextEditor(e) {
         if (this.focusEditorAfterClick && e.button === 0) {
-            atom.workspace.paneForItem(this.textEditorNow).activate();
+            pane = atom.workspace.paneForItem(this.textEditorNow);
+            if (pane != null)
+            pane.activate();
         }
     }
 


### PR DESCRIPTION
Addressing #11

### Changes

- When the TextEditorNow pane is destroyed and any node is selected in the LatexTreeView the issue in #11 doesn't occur. Behavior was already as expected.
- When the TextEditorNow pane is closed and a child node is selected the parent file will be opened.
