### PR TITLE
Added .latexcfg detection

### DIFF
--- a/lib/DocTree.js
+++ b/lib/DocTree.js
@@ -41,10 +41,10 @@ export default class DocTree {
         // Scan for .latexcfg with rootpath
         posiblepaths = atom.project.getPaths();
         for(i = 0; i < posiblepaths.length;i++) {
-          if (fs.readdirSync(posiblepaths[i]).includes(".latexcfg")){
+          if (fs.readdirSync(posiblepaths[i]).includes(".latexcfg")){ // Check if folder contains a .latexcfg file
             try{
               content = JSON.parse(fs.readFileSync(posiblepaths[i].concat("\\.latexcfg"))).root;
-              if (fs.existsSync(content)) {
+              if (fs.existsSync(content)) { // Check if root file exists
                 rootPath = content;
                 break;
               }

--- a/lib/DocTree.js
+++ b/lib/DocTree.js
@@ -2,6 +2,7 @@
 
 import { File, Directory, TextBuffer } from 'atom';
 import ParseObject from './ParseObject';
+fs = require('fs');
 
 const path = require('path');
 
@@ -35,8 +36,25 @@ export default class DocTree {
         // Add to docTree
         let buffNow = editor.getBuffer();
 
-        // Scan for potential root file
-        var rootPath = null;
+        var rootPath;
+
+        // Scan for .latexcfg with rootpath
+        posiblepaths = atom.project.getPaths();
+        for(i = 0; i < posiblepaths.length;i++) {
+          if (fs.readdirSync(posiblepaths[i]).includes(".latexcfg")){
+            try{
+              content = JSON.parse(fs.readFileSync(posiblepaths[i].concat("\\.latexcfg"))).root;
+              if (fs.existsSync(content)) {
+                rootPath = content;
+                break;
+              }
+            } catch (e) {
+              console.log(e);
+            }
+          }
+        }
+
+        // Scan for potential root file in magic comments
         let regEx = new RegExp(/% ?!(?:TEX|TeX) root = (.*)/);
         buffNow.backwardsScan(regEx, result => {
 


### PR DESCRIPTION
Latex tree is detecting the `.latexcfg` file. This is done before the magic comments are scanned so the magic comments would overwrite the `.latexcfg`